### PR TITLE
Add IMPLICIT_MEM_0 option to disable unnecessary bss, sbss zeroing

### DIFF
--- a/bsp/boot.S
+++ b/bsp/boot.S
@@ -165,18 +165,22 @@ _mstart:
     la	gp, _gp
 
 init_bss:
+#ifndef IMPLICIT_MEM_0
     /* init bss section */
     la	a0, __bss_start
     la	a1, __bss_end /* section end is actually the start of the next section */
     li	a2, 0x0
     jal	fill_block
+#endif
 
 init_sbss:
-    /* init bss section */
+#ifndef IMPLICIT_MEM_0
+    /* init sbss section */
     la	a0, __sbss_start
     la	a1, __sbss_end /* section end is actually the start of the next section */
     li	a2, 0x0
     jal	fill_block
+#endif
 
 write_stack_pattern:
     /* init bss section */

--- a/wscript
+++ b/wscript
@@ -1205,6 +1205,12 @@ def options(ctx):
                    action='store',
                    default="qemu_virt",
                    help='RISC-V Platform/Board')
+    
+    ctx.add_option('--implicit-mem-0',
+                   action='store_true',
+                   default=False,
+                   help='Set if running on a simulation platform which initializes memory to zero. '
+                   'This allows the boot phase to skip zero-initialization steps.')
 
     ctx.add_option('--mem-start',
                    action='store',
@@ -1344,6 +1350,9 @@ def configure(ctx):
     ctx.env.append_value('DEFINES', ['__freertos__=1'])
     ctx.env.append_value('DEFINES', ['__waf__=1'])
     ctx.env.append_value('DEFINES', ['HAVE_CONFIG_H=1'])
+
+    if ctx.options.implicit_mem_0:
+        ctx.env.append_value('DEFINES', ['IMPLICIT_MEM_0=1'])
 
     # TOOLCHAIN - Check for a valid installed toolchain
     if ctx.options.toolchain == "llvm":


### PR DESCRIPTION
Many RISC-V simulators start with memory implicitly zeroed. In these cases it can be unnecessary and extremely slow to zero out the .bss and .sbss sections. This commit adds --implicit-mem-0 to the wscript options, which defines IMPLICIT_MEM_0 in boot.S, which disables the 'fill_block' loops for those sections.

Stack initialization with 0xABABABAB is not disabled under IMPLICIT_MEM_0, because it isn't zero-initialization.