### PR TITLE
ISO C requires using __asm__ instead of asm keyword (-std=c11)

### DIFF
--- a/bsp/bsp.c
+++ b/bsp/bsp.c
@@ -131,12 +131,12 @@ plic_instance_t Plic;
                 rtems_rtl_obj * obj = NULL;
             #endif
 
-            asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-            asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
-            asm volatile ( "cspecialr %0, mepcc" : "=C" ( mepcc )::);
+            __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+            __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+            __asm__ volatile ( "cspecialr %0, mepcc" : "=C" ( mepcc )::);
 
             size_t ccsr = 0;
-            asm volatile ( "csrr %0, mtval" : "=r" ( ccsr )::);
+            __asm__ volatile ( "csrr %0, mtval" : "=r" ( ccsr )::);
 
             uint8_t reg_num = ( uint8_t ) ( ( ccsr >> 5 ) & 0x1f );
             int is_scr = ( ( ccsr >> 10 ) & 0x1 );
@@ -242,9 +242,9 @@ plic_instance_t Plic;
                 rtems_rtl_obj * obj = NULL;
             #endif
 
-            asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-            asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
-            asm volatile ( "csrr %0, mtval" : "=r" ( mtval )::);
+            __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+            __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+            __asm__ volatile ( "csrr %0, mtval" : "=r" ( mtval )::);
 
 
             #if (DEBUG)

--- a/demo/compartments/loader.c
+++ b/demo/compartments/loader.c
@@ -178,7 +178,7 @@ void vCompartmentsLoad( void )
         cheri_print_cap( call );
         printf( "CCalling captable -> " );
         cheri_print_cap( data_cap );
-        asm volatile ( ".balign 4\nccall %0, %1" : : "C" ( call ), "C" ( data_cap ) : );
+        __asm__ volatile ( ".balign 4\nccall %0, %1" : : "C" ( call ), "C" ( data_cap ) : );
     #else
         call();
     #endif

--- a/demo/ipc_benchmark/receiver_compartment.c
+++ b/demo/ipc_benchmark/receiver_compartment.c
@@ -62,7 +62,7 @@ void externFunc( void * pvParameters ) {
 void externFault( void * pvParameters ) {
     start_hpms.counters[COUNTER_INSTRET] = portCounterGet(COUNTER_INSTRET);
     start_hpms.counters[COUNTER_CYCLE] = portCounterGet(COUNTER_CYCLE);
-    asm volatile ("li a7, -1; ecall");
+    __asm__ volatile ("li a7, -1; ecall");
     //*((volatile int *) 0) = 0;
 }
 

--- a/demo/ipc_benchmark/sender_compartment.c
+++ b/demo/ipc_benchmark/sender_compartment.c
@@ -92,14 +92,14 @@ void ecall( void ) {
     for( int i = 0; i < DISCARD_RUNS; i++ ) {
         start_hpms.counters[COUNTER_INSTRET] = portCounterGet(COUNTER_INSTRET);
         start_hpms.counters[COUNTER_CYCLE] = portCounterGet(COUNTER_CYCLE);
-        asm volatile("li a7, 1; ecall");
+        __asm__ volatile("li a7, 1; ecall");
         end_hpms.counters[COUNTER_INSTRET] = portCounterGet(COUNTER_INSTRET);
         end_hpms.counters[COUNTER_CYCLE] = portCounterGet(COUNTER_CYCLE);
     }
 
     start_hpms.counters[COUNTER_CYCLE] = portCounterGet(COUNTER_CYCLE);
     start_hpms.counters[COUNTER_INSTRET] = portCounterGet(COUNTER_INSTRET);
-    asm volatile("li a7, 1; ecall");
+    __asm__ volatile("li a7, 1; ecall");
     end_hpms.counters[COUNTER_INSTRET] = portCounterGet(COUNTER_INSTRET);
     end_hpms.counters[COUNTER_CYCLE] = portCounterGet(COUNTER_CYCLE);
 

--- a/demo/main_compartment_test.c
+++ b/demo/main_compartment_test.c
@@ -143,11 +143,11 @@ static UBaseType_t cheri_exception_handler( uintptr_t * exception_frame )
         size_t epc = 0;
         size_t cheri_cause;
 
-        asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-        asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+        __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+        __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
 
         size_t ccsr = 0;
-        asm volatile ( "csrr %0, mccsr" : "=r" ( ccsr )::);
+        __asm__ volatile ( "csrr %0, mccsr" : "=r" ( ccsr )::);
 
         uint8_t reg_num = ( uint8_t ) ( ( ccsr >> 10 ) & 0x1f );
         bool is_scr = ( ( ccsr >> 15 ) & 0x1 );
@@ -183,8 +183,8 @@ static UBaseType_t default_exception_handler( uintptr_t * exception_frame )
     size_t cause = 0;
     size_t epc = 0;
 
-    asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-    asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+    __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+    __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
     printf( "mcause = %u\n", cause );
     printf( "mepc = %llx\n", epc );
 

--- a/demo/main_peekpoke.c
+++ b/demo/main_peekpoke.c
@@ -153,11 +153,11 @@ static UBaseType_t cheri_exception_handler( uintptr_t * exception_frame )
         size_t epc = 0;
         size_t cheri_cause;
 
-        asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-        asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+        __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+        __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
 
         size_t ccsr = 0;
-        asm volatile ( "csrr %0, mccsr" : "=r" ( ccsr )::);
+        __asm__ volatile ( "csrr %0, mccsr" : "=r" ( ccsr )::);
 
         uint8_t reg_num = ( uint8_t ) ( ( ccsr >> 10 ) & 0x1f );
         bool is_scr = ( ( ccsr >> 15 ) & 0x1 );
@@ -186,8 +186,8 @@ static UBaseType_t default_exception_handler( uintptr_t * exception_frame )
     size_t cause = 0;
     size_t epc = 0;
 
-    asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-    asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+    __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+    __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
     printf( "mcause = %u\n", cause );
     printf( "mepc = %llx\n", epc );
 

--- a/demo/main_servers.c
+++ b/demo/main_servers.c
@@ -352,11 +352,11 @@ static TaskHandle_t xServerWorkTaskHandle = NULL;
             size_t epc = 0;
             size_t cheri_cause;
 
-            asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-            asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+            __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+            __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
 
             size_t ccsr = 0;
-            asm volatile ( "csrr %0, mccsr" : "=r" ( ccsr )::);
+            __asm__ volatile ( "csrr %0, mccsr" : "=r" ( ccsr )::);
 
             uint8_t reg_num = ( uint8_t ) ( ( ccsr >> 10 ) & 0x1f );
             int is_scr = ( ( ccsr >> 15 ) & 0x1 );
@@ -385,8 +385,8 @@ static TaskHandle_t xServerWorkTaskHandle = NULL;
         size_t cause = 0;
         size_t epc = 0;
 
-        asm volatile ( "csrr %0, mcause" : "=r" ( cause )::);
-        asm volatile ( "csrr %0, mepc" : "=r" ( epc )::);
+        __asm__ volatile ( "csrr %0, mcause" : "=r" ( cause )::);
+        __asm__ volatile ( "csrr %0, mepc" : "=r" ( epc )::);
         printf( "mcause = %u\n", cause );
         printf( "mepc = %llx\n", epc );
 

--- a/main.c
+++ b/main.c
@@ -111,7 +111,7 @@ void vToggleLED( void );
 #if __riscv_xlen == 64
     #define read_csr( reg )                                  \
     ( { unsigned long __tmp;                                 \
-        asm volatile ( "csrr %0, " # reg : "=r" ( __tmp ) ); \
+        __asm__ volatile ( "csrr %0, " # reg : "=r" ( __tmp ) ); \
         __tmp; } )
 #endif
 
@@ -124,7 +124,7 @@ uint64_t get_cycle_count( void )
         return read_csr( cycle );
     #else
         uint32_t cycle_lo, cycle_hi;
-        asm volatile (
+        __asm__ volatile (
             "%=:\n\t"
             "csrr %1, cycleh\n\t"
             "csrr %0, cycle\n\t"
@@ -391,7 +391,7 @@ void vApplicationMallocFailedHook( void )
      * to query the size of free heap space that remains (although it does not
      * provide information on how the remaining heap might be fragmented). */
     taskDISABLE_INTERRUPTS();
-    __asm volatile ( "ebreak" );
+    __asm__ volatile ( "ebreak" );
 
     for( ; ; )
     {
@@ -423,7 +423,7 @@ void vApplicationStackOverflowHook( TaskHandle_t pxTask,
      * configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
      * function is called if a stack overflow is detected. */
     taskDISABLE_INTERRUPTS();
-    __asm volatile ( "ebreak" );
+    __asm__ volatile ( "ebreak" );
 
     for( ; ; )
     {


### PR DESCRIPTION
Here is the [reference](https://en.cppreference.com/w/c/language/asm)
> When compiling in ISO C mode by GCC or Clang (e.g. with option -std=c11), \_\_asm\_\_ must be used instead of asm. 